### PR TITLE
fix(ExpressiveCard): use CarbonIconType for pictogram

### DIFF
--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -7,6 +7,7 @@
 
 import React, { PropsWithChildren, ReactNode, forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
 import { Card } from '../Card';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -66,7 +67,7 @@ interface ExpressiveCardProps extends PropsWithChildren {
   /**
    * Provides the icon that's displayed at the top of the card
    */
-  pictogram?: () => void | object;
+  pictogram?: CarbonIconType;
   /**
    * Optionally specify an href for your Button to become an <a> element
    */


### PR DESCRIPTION
Closes #

```
Type error: Type 'CarbonIconType' is not assignable to type '() => void | object'.
  Target signature provides too few arguments. Expected 1 or more, but got 0.

> 20 |           pictogram={category.icon}
     |           ^

```

#### What did you change?

Use `CarbonIconType`

#### How did you test and verify your work?
